### PR TITLE
chore: hide login to listen infobar

### DIFF
--- a/packages/player-component/index.js
+++ b/packages/player-component/index.js
@@ -315,12 +315,9 @@ class Player extends Nanocomponent {
   }
 
   renderPlayer () {
-    const isAuthenticated = !!this.state.user.uid
     const classesInfoBar = 'flex flex-row w-100 justify-center bb b--light-silver no-underline'
     let infoBar = ''
-    if (!isAuthenticated) {
-      infoBar = html`<a class=${classesInfoBar} href="/login" target="_blank" rel="noopener noreferer">Log in to listen to full song</a>`
-    } else if (Number(this.state.user.credits) < 0.002 && this.local.count < 9) {
+    if (Number(this.state.user.credits) < 0.002 && this.local.count < 9) {
       infoBar = html`<a class=${classesInfoBar}>You don’t have enough credits to play the current track in full’</a>`
     }
 


### PR DESCRIPTION
Because we're [disabling login](https://github.com/litesolutions/justifay-stream-app/pull/15), we should also hide the infobar informing users that they need to login to listen to entire tracks.

This closes #17.